### PR TITLE
Fixed path to simulator_sdk in runtime.ini

### DIFF
--- a/controllers/naoqisim/runtime.ini
+++ b/controllers/naoqisim/runtime.ini
@@ -1,12 +1,12 @@
 [environment variables for Windows]
-WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)/msys64/mingw32/bin;$(WEBOTS_HOME)/projects/robots/aldebaran/aldebaran/simulator-sdk/bin"
+WEBOTS_LIBRARY_PATH = "$(WEBOTS_HOME)/msys64/mingw32/bin;../../aldebaran/simulator-sdk/bin"
 
 [environment variables for macOS]
-DYLD_FRAMEWORK_PATH = $(DYLD_FRAMEWORK_PATH):$(WEBOTS_HOME)/projects/robots/aldebaran/aldebaran/simulator-sdk/
-WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/projects/robots/aldebaran/aldebaran/simulator-sdk/lib
+DYLD_FRAMEWORK_PATH = $(DYLD_FRAMEWORK_PATH):../../aldebaran/simulator-sdk/
+WEBOTS_LIBRARY_PATH = ../../aldebaran/simulator-sdk/lib
 
 [environment variables for Linux]
-WEBOTS_LIBRARY_PATH = $(WEBOTS_HOME)/projects/robots/aldebaran/aldebaran/simulator-sdk/lib
+WEBOTS_LIBRARY_PATH = ../../aldebaran/simulator-sdk/lib
 
 [environment variables with relative paths]
-WEBOTS_NAOSIM_PATH = $(WEBOTS_HOME)/projects/robots/aldebaran/aldebaran/simulator-sdk
+WEBOTS_NAOSIM_PATH = "../../aldebaran/simulator-sdk"


### PR DESCRIPTION
The `naoqisim` controller was crashing without a correct path to simulator_sdk.

👍 