### PR TITLE
Improve Compilation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Version R2018a was recently tested and is known to work with naoqisim.
 ## Build
 
 Set the `WEBOTS_HOME` environment variable to point to the Webots installation folder, as documented in the Webots user guide.
+Add `WEBOTS_HOME/lib` to your library path (e.g. for Linux: `export LD_LIBRARY_PATH=$WEBOTS_HOME/lib`).
 
 ### Windows
 Open the MSYS2 console, `cd` to the naoqisim root directory. Type `make` to complete the installation of the Simulator SDK and the naoqisim controller. On the Simulator SDK is installed, you can compile the naoqisim controller by opening `controllers/naoqisim/naoqisim.sln` with Visual C++ to build the project.

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Version R2018a was recently tested and is known to work with naoqisim.
 ## Build
 
 Set the `WEBOTS_HOME` environment variable to point to the Webots installation folder, as documented in the Webots user guide.
-Add `WEBOTS_HOME/lib` to your library path (e.g. for Linux: `export LD_LIBRARY_PATH=$WEBOTS_HOME/lib`).
 
 ### Windows
 Open the MSYS2 console, `cd` to the naoqisim root directory. Type `make` to complete the installation of the Simulator SDK and the naoqisim controller. On the Simulator SDK is installed, you can compile the naoqisim controller by opening `controllers/naoqisim/naoqisim.sln` with Visual C++ to build the project.
 
 ### Linux
+Add `WEBOTS_HOME/lib` to your library path (e.g. `export LD_LIBRARY_PATH=$WEBOTS_HOME/lib`).
 Type `make` in the naoqisim root directory to install the Simulation SDK and naoqisim controller. Once the Simulation SDK is installed, you can compile the naoqisim controller by typing `make` in the `controllers/naoqisim` folder.
 
 ## Use


### PR DESCRIPTION
If the Webots development environment is not installed it might be required to add `WEBOTS_HOME/lib` to the path.